### PR TITLE
Quota pmlogger log directory path

### DIFF
--- a/manifests/pmlogger.pp
+++ b/manifests/pmlogger.pp
@@ -34,7 +34,7 @@ define pcp::pmlogger (
   }
 
   $_pmlogger_config_path = "/etc/pcp/pmlogger/control.d/${name}"
-  $_line = "#This file is managed by Puppet\n${hostname} ${_primary} ${_socks} ${log_dir} ${_args}\n"
+  $_line = "#This file is managed by Puppet\n${hostname} ${_primary} ${_socks} \"${log_dir}\" ${_args}\n"
 
   file { "pmlogger-${name}":
     ensure  => $ensure,

--- a/spec/defines/pcp_pmlogger_spec.rb
+++ b/spec/defines/pcp_pmlogger_spec.rb
@@ -21,7 +21,7 @@ describe 'pcp::pmlogger' do
           :owner    => 'root',
           :group    => 'root',
           :mode     => '0644',
-          :content  => "#This file is managed by Puppet\nLOCALHOSTNAME y n PCP_LOG_DIR/pmlogger/LOCALHOSTNAME -r -T24h10m -c config.default\n",
+          :content  => "#This file is managed by Puppet\nLOCALHOSTNAME y n \"PCP_LOG_DIR/pmlogger/LOCALHOSTNAME\" -r -T24h10m -c config.default\n",
           :notify   => 'Service[pmlogger]',
         })
       end
@@ -50,7 +50,7 @@ describe 'pcp::pmlogger' do
             :owner    => 'root',
             :group    => 'root',
             :mode     => '0644',
-            :content  => "#This file is managed by Puppet\nLOCALHOSTNAME y n /dne/supremm/LOCALHOSTNAME -r -c /etc/pcp/pmlogger/pmlogger-supremm.config\n",
+            :content  => "#This file is managed by Puppet\nLOCALHOSTNAME y n \"/dne/supremm/LOCALHOSTNAME\" -r -c /etc/pcp/pmlogger/pmlogger-supremm.config\n",
             :notify   => 'Service[pmlogger]',
           })
         end


### PR DESCRIPTION
Quoting the pmlogger log directory path allows for things like $(date +%Y/%m/%d) to be added to path