### PR TITLE
Fix service start order for pmcd and pmlogger

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,15 +15,13 @@ class pcp::service {
     hasstatus  => true,
     hasrestart => true,
   }
-
-  service { 'pmlogger':
+  -> service { 'pmlogger':
     ensure     => $pcp::_service_ensure,
     enable     => $pcp::_service_enable,
     hasstatus  => true,
     hasrestart => true,
   }
-
-  service { 'pmie':
+  -> service { 'pmie':
     ensure     => $pcp::_service_ensure,
     enable     => $pcp::_service_enable,
     hasstatus  => true,

--- a/spec/shared_examples/pcp_service.rb
+++ b/spec/shared_examples/pcp_service.rb
@@ -7,6 +7,7 @@ shared_examples_for 'pcp::service' do |facts|
       :hasrestart => 'true',
     })
   end
+  it { is_expected.to contain_service('pmcd').that_comes_before('Service[pmlogger]') }
 
   it do
     is_expected.to contain_service('pmlogger').with({
@@ -16,6 +17,7 @@ shared_examples_for 'pcp::service' do |facts|
       :hasrestart => 'true',
     })
   end
+  it { is_expected.to contain_service('pmlogger').that_comes_before('Service[pmie]') }
 
   it do
     is_expected.to contain_service('pmie').with({


### PR DESCRIPTION
pmlogger will fail to start if pmcd is not already running.