### PR TITLE
Add hooks for pmie and pmlogger resources.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,10 @@
 #   Hash of configs to manage in /etc/pcp.conf.
 # @param pmdas
 #   Hash that defines `pcp::pmda` resources.
+# @param pmies
+#   Hash that defines `pcp::pmie` resources.
+# @param pmloggers
+#   Hash that defines `pcp::pmlogger` resources.
 #
 class pcp (
   Enum['running', 'stopped', 'absent'] $ensure  = 'running',
@@ -67,6 +71,8 @@ class pcp (
   Hash $pcp_conf_configs                        = {},
   # Resources
   Hash $pmdas                                   = {},
+  Hash $pmies                                   = {},
+  Hash $pmloggers                               = {},
 ) {
 
   case $ensure {

--- a/manifests/resources.pp
+++ b/manifests/resources.pp
@@ -2,5 +2,7 @@
 class pcp::resources {
 
   create_resources('pcp::pmda', $pcp::pmdas)
+  create_resources('pcp::pmie', $pcp::pmies)
+  create_resources('pcp::pmlogger', $pcp::pmloggers)
 
 }

--- a/spec/shared_examples/pcp_resources.rb
+++ b/spec/shared_examples/pcp_resources.rb
@@ -1,7 +1,7 @@
 shared_examples_for 'pcp::resources' do |_facts|
   it { is_expected.to have_pcp__pmda_resource_count(0) }
-  it { is_expected.to have_pcp__pmie_resource_count(0) }
-  it { is_expected.to have_pcp__pmlogger_resource_count(0) }
+  it { is_expected.to have_pcp__pmie_resource_count(1) }
+  it { is_expected.to have_pcp__pmlogger_resource_count(1) }
 
   context 'when pmdas defined' do
     let(:params) do

--- a/spec/shared_examples/pcp_resources.rb
+++ b/spec/shared_examples/pcp_resources.rb
@@ -27,10 +27,10 @@ shared_examples_for 'pcp::resources' do |_facts|
     it { is_expected.to have_pcp__pmda_resource_count(1) }
     it { is_expected.to contain_pcp__pmda('test').with_has_package('true') }
 
-    it { is_expected.to have_pcp__pmie_resource_count(1) }
+    it { is_expected.to have_pcp__pmie_resource_count(2) }
     it { is_expected.to contain_pcp__pmie('test').with_log_file('EXAMPLE') }
 
-    it { is_expected.to have_pcp__pmlogger_resource_count(1) }
+    it { is_expected.to have_pcp__pmlogger_resource_count(2) }
     it { is_expected.to contain_pcp__pmlogger('test').with_log_dir('EXAMPLE') }
   end
 end

--- a/spec/shared_examples/pcp_resources.rb
+++ b/spec/shared_examples/pcp_resources.rb
@@ -1,5 +1,7 @@
 shared_examples_for 'pcp::resources' do |_facts|
   it { is_expected.to have_pcp__pmda_resource_count(0) }
+  it { is_expected.to have_pcp__pmie_resource_count(0) }
+  it { is_expected.to have_pcp__pmlogger_resource_count(0) }
 
   context 'when pmdas defined' do
     let(:params) do
@@ -9,10 +11,26 @@ shared_examples_for 'pcp::resources' do |_facts|
             'has_package' => true,
           },
         },
+        pmies: {
+          'test' => {
+            'log_file' => 'EXAMPLE',
+          },
+        },
+        pmloggers: {
+          'test' => {
+            'log_dir' => 'EXAMPLE',
+          },
+        },
       }
     end
 
     it { is_expected.to have_pcp__pmda_resource_count(1) }
     it { is_expected.to contain_pcp__pmda('test').with_has_package('true') }
+
+    it { is_expected.to have_pcp__pmie_resource_count(1) }
+    it { is_expected.to contain_pcp__pmie('test').with_log_file('EXAMPLE') }
+
+    it { is_expected.to have_pcp__pmlogger_resource_count(1) }
+    it { is_expected.to contain_pcp__pmlogger('test').with_log_dir('EXAMPLE') }
   end
 end


### PR DESCRIPTION
This commit adds place to easily define additional `pmie`
and `pmlogger` resources via arguments to `init.pp`